### PR TITLE
Bugfixes: repeated logic, wrong type inheritance

### DIFF
--- a/docker/bootstrap_mibi_pixels.py
+++ b/docker/bootstrap_mibi_pixels.py
@@ -196,14 +196,14 @@ def calculate_percentile_weights(pixel_stack, thresh=0.5):
     in the channel, it will be given the value 0.01, or 87% 0.13 and
     so on."""
     perc_thresh = int(100 * thresh)
-    output = np.zeros_like(pixel_stack)
+    output = np.zeros(pixel_stack.shape, dtype=np.float32)
     for i in range(0, pixel_stack.shape[1]):
         this_chan = pixel_stack[:, i]
         this_chan_nz = this_chan[np.where(this_chan > 0.01)]
         breaks = np.arange(perc_thresh, 100, 1)
         perc = np.percentile(this_chan_nz, breaks)
         break_lookup = np.searchsorted(perc, this_chan)
-        output[:, i] = 1.0 - (((np.searchsorted(perc, this_chan) - 1) * 0.01) + thresh)
+        output[:, i] = 1.0 - (((break_lookup) - 1) * 0.01) + thresh)
     return output
 
 


### PR DESCRIPTION
Fixes for:
- searchsorted is run twice and the intermediate output isn't used.
- zeros_like will make an array of ints when the passed pixels are an int type, which is very bad when you're generating values from 0.0-1.0. This fixes it so it's always a float. Low precision is fine to save on mem (since these arrays are usually quite large).