### PR TITLE
Fix index ordering issue with empty list matrix allocation

### DIFF
--- a/docker/expand_segmentation.py
+++ b/docker/expand_segmentation.py
@@ -57,7 +57,7 @@ args = parser.parse_args()
 
 def alloc_matrix2d(W, H):
     """ Pre-allocate a 2D matrix of empty lists. """
-    return [ [ [] for i in range(W) ] for j in range(H) ]
+    return [ [ [] for i in range(H) ] for j in range(W) ]
 
 
 def find_dist(overlap_seg_idx, centroids, pix_idx):


### PR DESCRIPTION
Numpy arrays for images are ordered `H x W` (i.e. `Y x X`), or, for multichannel images, `Y x X x Z` (`H x W x D`). This fixes the initialization of the matrix of empty lists used in segment expansion so that the nesting order of the lists corresponds to an image with the correct dimensions and can be iterated over accordingly. This fix was necessary when adapting the pipeline to CODEX data and can be verified against public codex data (e.g. from [The Cancer Imaging Archive](https://wiki.cancerimagingarchive.net/pages/viewpage.action?pageId=70227790)).

This issue wasn't encountered in the original development of the pipeline as this was done against square images where `X == Y` / `H == W`.


